### PR TITLE
Fix CMake error due to missing testing directory

### DIFF
--- a/SlicerDESI/CMakeLists.txt
+++ b/SlicerDESI/CMakeLists.txt
@@ -29,6 +29,4 @@ if(BUILD_TESTING)
   # Note that the test will also be available at runtime.
   slicer_add_python_unittest(SCRIPT ${MODULE_NAME}.py)
 
-  # Additional build-time testing
-  add_subdirectory(Testing)
 endif()


### PR DESCRIPTION
Removed Testing subdirectory reference from SlicerDESI module.